### PR TITLE
Fix usage with Symfony in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,12 @@ services:
             $localBlueScreenDirectory: '%kernel.logs_dir%'
         tags:
             - { name: monolog.logger }
+
+monolog:
+    handlers:
+        tracy:
+            type: service
+            id: Mangoweb\MonologTracyHandler\TracyHandler
 ```
 
 You can optionally configure remote storage for Tracy bluescreens.


### PR DESCRIPTION
When I set up the handler according to your readme no tracy dumps were created. Apparently I also need to register the handler to monolog.