### PR TITLE
Automatically create local bluescreen directory

### DIFF
--- a/src/TracyHandler.php
+++ b/src/TracyHandler.php
@@ -56,6 +56,10 @@ class TracyHandler extends AbstractProcessingHandler
 		$blueScreen = Tracy\Debugger::getBlueScreen();
 		$blueScreen->addPanel([$this, 'renderPsrLogPanel']);
 
+		if (!is_dir($this->localBlueScreenDirectory)) {
+			mkdir($this->localBlueScreenDirectory, 0777, true);
+		}
+
 		if ($blueScreen->renderToFile($exception, $localPath)) {
 			$this->remoteStorageDriver->upload($localPath);
 		}


### PR DESCRIPTION
If it didn't exist bluescreens were not saved.

I've tested the change locally in the project where I'm using `mangoweb/monolog-tracy-handler`.

Closes #4