### PR TITLE
Maintenance pass: upgrade deps, extend PHP matrix to 8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,18 +16,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
         dependencies: ['--prefer-lowest', '']
 
     name: PHP ${{ matrix.php }} ${{ matrix.dependencies }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
 
-      - run: composer update --no-progress ${{ matrix.dependecies }}
+      - run: composer update --no-progress ${{ matrix.dependencies }}
 
       - name: PHPStan
         run: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,15 @@
 	"description": "Integrates Tracy into Monolog, supports uploading Tracy bluescreens to AWS S3",
 	"license": "MIT",
 	"require": {
-		"php": "~8.1",
+		"php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"mangoweb/clock": "~0.2.0",
 		"monolog/monolog": "~3.0",
-		"tracy/tracy": "~2.6"
+		"tracy/tracy": "~2.10"
 	},
 	"require-dev": {
-		"mockery/mockery": "~1.5",
-		"nette/tester": "~2.4",
-		"phpstan/phpstan": "~1.6"
+		"mockery/mockery": "~1.6.12",
+		"nette/tester": "~2.5.7",
+		"phpstan/phpstan": "~2.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,3 @@
 parameters:
 	level: max
 	paths: [src]
-
-	checkMissingIterableValueType: false

--- a/src/TracyHandler.php
+++ b/src/TracyHandler.php
@@ -14,6 +14,7 @@ class TracyHandler extends AbstractProcessingHandler
 {
 	private ?string $lastMessage = null;
 
+	/** @var array<array-key, mixed>|null */
 	private ?array $lastContext = null;
 
 	private const UPLOADED_FILE_CONTENTS = 'Uploaded to remote storage.';

--- a/tests/unit/TracyProcessorTest.phpt
+++ b/tests/unit/TracyProcessorTest.phpt
@@ -59,13 +59,15 @@ use Tester\TestCase;
 
 		public function testInvokeWithExceptionNullStorage(): void
 		{
+			$exception = $this->createException();
+			$expectedFileName = 'exception--2018-10-09--acff8ba9d4.html';
+
 			$storageDriver = Mockery::mock(RemoteStorageDriver::class);
 			$storageDriver->expects('getUrl')
-				->with('exception--2018-10-09--b48e85fdbd.html')
+				->with($expectedFileName)
 				->andReturnNull();
 
 			$processor = new TracyProcessor($storageDriver);
-			$exception = $this->createException();
 
 			Assert::same(
 				[
@@ -78,7 +80,7 @@ use Tester\TestCase;
 					'channel' => 'app',
 					'datetime' => Clock::now(),
 					'extra' => [
-						'tracy_filename' => 'exception--2018-10-09--b48e85fdbd.html',
+						'tracy_filename' => $expectedFileName,
 					],
 				],
 				$processor(new LogRecord(
@@ -94,13 +96,15 @@ use Tester\TestCase;
 
 		public function testInvokeWithExceptionStorage(): void
 		{
+			$exception = $this->createException();
+			$expectedFileName = 'exception--2018-10-09--acff8ba9d4.html';
+
 			$storageDriver = Mockery::mock(RemoteStorageDriver::class);
 			$storageDriver->expects('getUrl')
-				->with('exception--2018-10-09--96577eb4c8.html')
+				->with($expectedFileName)
 				->andReturn('https://example.com/foo.html');
 
 			$processor = new TracyProcessor($storageDriver);
-			$exception = $this->createException();
 
 			Assert::same(
 				[
@@ -113,7 +117,7 @@ use Tester\TestCase;
 					'channel' => 'app',
 					'datetime' => Clock::now(),
 					'extra' => [
-						'tracy_filename' => 'exception--2018-10-09--96577eb4c8.html',
+						'tracy_filename' => $expectedFileName,
 						'tracy_url' => 'https://example.com/foo.html',
 					]
 				],
@@ -151,21 +155,9 @@ use Tester\TestCase;
 			$exception = new \Exception();
 			$reflection = new \ReflectionClass($exception);
 
-			$filePropertyReflection = $reflection->getProperty('file');
-			$filePropertyReflection->setValue($exception, '/src/foo/bar.txt');
-
-			$linePropertyReflection = $reflection->getProperty('line');
-			$linePropertyReflection->setValue($exception, 123);
-
-			$tracyPropertyReflection = $reflection->getProperty('trace');
-			$tracyPropertyReflection->setValue($exception, array_map(
-				static function (array $frame): array {
-					$frame['file'] = strtr(str_replace(dirname(__FILE__, 3), '', $frame['file'] ?? ''), '\\', '/');
-					$frame['line'] = 123;
-					return $frame;
-				},
-				$exception->getTrace()
-			));
+			$reflection->getProperty('file')->setValue($exception, '/src/foo/bar.txt');
+			$reflection->getProperty('line')->setValue($exception, 123);
+			$reflection->getProperty('trace')->setValue($exception, []);
 
 			return $exception;
 		}


### PR DESCRIPTION
## Summary
- Extend CI matrix to PHP 8.4 and 8.5, upgrade `actions/checkout` to v4, and fix a `dependecies`/`dependencies` typo that was silently dropping the `--prefer-lowest` flag.
- Upgrade dev dependencies: phpstan to ~2.1, mockery to ~1.6.12 (PHP 8.4 deprecation fixes), nette/tester to ~2.5.5, tracy to ~2.10.
- Stabilize `TracyProcessorTest` — the expected file name was hashed from the live call stack, so it drifted whenever PHP or nette/tester changed the trace format. Reset the trace to `[]` and use a deterministic expected hash.
- Pin PHP to `~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0` to document the tested range, and add a PHPDoc value type for `TracyHandler::$lastContext` required by phpstan level max.

## Test plan
- [x] `vendor/bin/phpstan analyse` passes on latest deps
- [x] `vendor/bin/tester tests/unit` passes on latest deps
- [x] `vendor/bin/phpstan analyse` passes with `composer update --prefer-lowest`
- [x] `vendor/bin/tester tests/unit` passes with `composer update --prefer-lowest`
- [ ] GitHub Actions matrix is green across PHP 8.1–8.5 × {lowest, latest}

Co-Authored-By: Claude Code