### PR TITLE
AwsS3RemoteStorageDriver: make X-Amz-ACL header optional

### DIFF
--- a/src/RemoteStorageDrivers/AwsS3Acl.php
+++ b/src/RemoteStorageDrivers/AwsS3Acl.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Mangoweb\MonologTracyHandler\RemoteStorageDrivers;
+
+
+enum AwsS3Acl: string
+{
+	case Private = 'private';
+	case PublicRead = 'public-read';
+	case PublicReadWrite = 'public-read-write';
+	case AuthenticatedRead = 'authenticated-read';
+	case AwsExecRead = 'aws-exec-read';
+	case BucketOwnerRead = 'bucket-owner-read';
+	case BucketOwnerFullControl = 'bucket-owner-full-control';
+	case LogDeliveryWrite = 'log-delivery-write';
+}

--- a/src/RemoteStorageDrivers/AwsS3RemoteStorageDriver.php
+++ b/src/RemoteStorageDrivers/AwsS3RemoteStorageDriver.php
@@ -17,7 +17,8 @@ class AwsS3RemoteStorageDriver implements RemoteStorageDriver
 		private string $prefix,
 		private string $accessKeyId,
 		private string $secretKey,
-		private RemoteStorageRequestSender $requestSender
+		private RemoteStorageRequestSender $requestSender,
+		private ?AwsS3Acl $acl = null,
 	) {
 	}
 
@@ -41,10 +42,13 @@ class AwsS3RemoteStorageDriver implements RemoteStorageDriver
 		$headers = [
 			'Host' => $this->getUrlHost(),
 			'User-Agent' => 'MangoLogger',
-			'X-Amz-ACL' => 'public-read',
 			'X-Amz-Content-Sha256' => self::UNSIGNED_PAYLOAD_HASH,
 			'X-Amz-Date' => Clock::now()->format('Ymd\THis\Z'),
 		];
+
+		if ($this->acl !== null) {
+			$headers['X-Amz-ACL'] = $this->acl->value;
+		}
 
 		$headers['Authorization'] = $this->getAuthorizationHeader($method, $path, $headers, self::UNSIGNED_PAYLOAD_HASH);
 		$headers['Content-Type'] = 'text/html; charset=utf-8'; // cannot be included in the Authorization signature

--- a/tests/unit/RemoteStorageDrivers/AwsS3RemoteStorageDriverTest.phpt
+++ b/tests/unit/RemoteStorageDrivers/AwsS3RemoteStorageDriverTest.phpt
@@ -3,6 +3,7 @@
 namespace MangowebTests\MonologTracyHandler\RemoteStorageDrivers;
 
 use Mangoweb\Clock\ClockMock;
+use Mangoweb\MonologTracyHandler\RemoteStorageDrivers\AwsS3Acl;
 use Mangoweb\MonologTracyHandler\RemoteStorageDrivers\AwsS3RemoteStorageDriver;
 use Mangoweb\MonologTracyHandler\RemoteStorageRequestSender;
 use Mockery;
@@ -49,6 +50,31 @@ use Tester\TestCase;
 					Assert::same('https://s3.eu-central-1.amazonaws.com/my-app/logs/a5ef95ed6b795b3dfed85238d3003cae.html', $url);
 					Assert::same('/src/log/exception--2018-10-09--144c575abe.html', $bodyFilePath);
 
+					Assert::count(6, $headers);
+					Assert::same('s3.eu-central-1.amazonaws.com', $headers['Host']);
+					Assert::same('MangoLogger', $headers['User-Agent']);
+					Assert::same('UNSIGNED-PAYLOAD', $headers['X-Amz-Content-Sha256']);
+					Assert::same('20181009T213200Z', $headers['X-Amz-Date']);
+					Assert::same('AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20181009/eu-central-1/s3/aws4_request, SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=f6911c67f86b2c8961f2933463b07a77293b5110433efe3e2cfe4d515119442f', $headers['Authorization']);
+					Assert::same('text/html; charset=utf-8', $headers['Content-Type']);
+
+					return true;
+				});
+
+			$storageDriver = $this->createStorageDriver($requestSender);
+			Assert::true($storageDriver->upload('/src/log/exception--2018-10-09--144c575abe.html'));
+		}
+
+
+		public function testUploadWithAcl(): void
+		{
+			$requestSender = Mockery::mock(RemoteStorageRequestSender::class);
+			$requestSender->expects('sendRequest')
+				->andReturnUsing(function (string $method, string $url, array $headers, string $bodyFilePath): bool {
+					Assert::same('PUT', $method);
+					Assert::same('https://s3.eu-central-1.amazonaws.com/my-app/logs/a5ef95ed6b795b3dfed85238d3003cae.html', $url);
+					Assert::same('/src/log/exception--2018-10-09--144c575abe.html', $bodyFilePath);
+
 					Assert::count(7, $headers);
 					Assert::same('s3.eu-central-1.amazonaws.com', $headers['Host']);
 					Assert::same('MangoLogger', $headers['User-Agent']);
@@ -61,12 +87,12 @@ use Tester\TestCase;
 					return true;
 				});
 
-			$storageDriver = $this->createStorageDriver($requestSender);
+			$storageDriver = $this->createStorageDriver($requestSender, AwsS3Acl::PublicRead);
 			Assert::true($storageDriver->upload('/src/log/exception--2018-10-09--144c575abe.html'));
 		}
 
 
-		private function createStorageDriver(RemoteStorageRequestSender $requestSender): AwsS3RemoteStorageDriver
+		private function createStorageDriver(RemoteStorageRequestSender $requestSender, ?AwsS3Acl $acl = null): AwsS3RemoteStorageDriver
 		{
 			return new AwsS3RemoteStorageDriver(
 				'eu-central-1',
@@ -74,7 +100,8 @@ use Tester\TestCase;
 				'logs/',
 				'AKIAIOSFODNN7EXAMPLE',
 				' wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-				$requestSender
+				$requestSender,
+				$acl,
 			);
 		}
 	}


### PR DESCRIPTION
## Summary
Resolves #12 with an enum-based, null-default API instead of the originally proposed boolean flag.

- Add an `AwsS3Acl` enum covering the AWS canned ACL values (`private`, `public-read`, `public-read-write`, `authenticated-read`, `aws-exec-read`, `bucket-owner-read`, `bucket-owner-full-control`, `log-delivery-write`).
- Add an optional `?AwsS3Acl $acl = null` constructor parameter. When `null` (the new default) the `X-Amz-ACL` header is omitted, which is required for buckets with Object Ownership set to "Bucket owner enforced".
- Existing callers that relied on the hard-coded `public-read` ACL must now pass `AwsS3Acl::PublicRead` explicitly.

## Test plan
- [x] `vendor/bin/phpstan analyse`
- [x] `vendor/bin/tester tests/unit` (existing `testUploadOk` covers the new default of no ACL header; new `testUploadWithAcl` covers the enum path with the original signed-headers signature)

Co-Authored-By: Claude Code