### PR TITLE
ExecCurlRequestSender: upload from temp copy in async mode

### DIFF
--- a/src/RemoteStorageRequestSenders/ExecCurlRequestSender.php
+++ b/src/RemoteStorageRequestSenders/ExecCurlRequestSender.php
@@ -24,28 +24,71 @@ class ExecCurlRequestSender implements RemoteStorageRequestSender
 	 */
 	public function sendRequest(string $method, string $url, array $headers, string $bodyFilePath): bool
 	{
-		$args = [$this->curlBinary];
-
-		$args[] = '--request';
-		$args[] = $method;
-
-		$args[] = '--url';
-		$args[] = $url;
+		$baseArgs = [$this->curlBinary, '--request', $method, '--url', $url];
 
 		foreach ($headers as $headerName => $headerValue) {
-			$args[] = '--header';
-			$args[] = "$headerName: $headerValue";
+			$baseArgs[] = '--header';
+			$baseArgs[] = "$headerName: $headerValue";
 		}
 
-		$args[] = '--upload-file';
-		$args[] = $bodyFilePath;
+		if (!$this->async) {
+			return $this->execSync([...$baseArgs, '--upload-file', $bodyFilePath]);
+		}
 
-		$escapedArgs = array_map('escapeshellarg', $args);
-		$asyncMarker = $this->async ? ' &' : '';
+		// In async mode the backgrounded curl process keeps reading $bodyFilePath
+		// after sendRequest() returns, so the caller can race us by overwriting
+		// or deleting the file. Upload from a temp copy instead and remove it
+		// from the background shell once curl is done.
+		$tempPath = $this->createUploadCopy($bodyFilePath);
 
-		$command = implode(' ', $escapedArgs) . ' >/dev/null 2>&1' . $asyncMarker;
+		if ($tempPath === null) {
+			return $this->execSync([...$baseArgs, '--upload-file', $bodyFilePath]);
+		}
+
+		return $this->execAsync([...$baseArgs, '--upload-file', $tempPath], $tempPath);
+	}
+
+
+	/**
+	 * @param list<string> $args
+	 */
+	private function execSync(array $args): bool
+	{
+		$command = implode(' ', array_map('escapeshellarg', $args)) . ' >/dev/null 2>&1';
 		exec($command, $output, $exitCode);
 
 		return $exitCode === 0;
+	}
+
+
+	/**
+	 * @param list<string> $args
+	 */
+	private function execAsync(array $args, string $tempPath): bool
+	{
+		$curl = implode(' ', array_map('escapeshellarg', $args));
+		$cleanup = 'rm -f ' . escapeshellarg($tempPath);
+		$command = "($curl >/dev/null 2>&1; $cleanup) >/dev/null 2>&1 &";
+		exec($command, $output, $exitCode);
+
+		return $exitCode === 0;
+	}
+
+
+	private function createUploadCopy(string $bodyFilePath): ?string
+	{
+		$tempPath = @tempnam(sys_get_temp_dir(), 'tracy-upload-');
+
+		if ($tempPath === false) {
+			return null;
+		}
+
+		if (!@copy($bodyFilePath, $tempPath)) {
+			@unlink($tempPath);
+
+			return null;
+		}
+
+		return $tempPath;
 	}
 }

--- a/src/RemoteStorageRequestSenders/ExecCurlRequestSender.php
+++ b/src/RemoteStorageRequestSenders/ExecCurlRequestSender.php
@@ -68,7 +68,7 @@ class ExecCurlRequestSender implements RemoteStorageRequestSender
 	{
 		$curl = implode(' ', array_map('escapeshellarg', $args));
 		$cleanup = 'rm -f ' . escapeshellarg($tempPath);
-		$command = "($curl >/dev/null 2>&1; $cleanup) >/dev/null 2>&1 &";
+		$command = "($curl; $cleanup) >/dev/null 2>&1 &";
 		exec($command, $output, $exitCode);
 
 		return $exitCode === 0;

--- a/src/RemoteStorageRequestSenders/ExecCurlRequestSender.php
+++ b/src/RemoteStorageRequestSenders/ExecCurlRequestSender.php
@@ -71,7 +71,14 @@ class ExecCurlRequestSender implements RemoteStorageRequestSender
 		$command = "($curl; $cleanup) >/dev/null 2>&1 &";
 		exec($command, $output, $exitCode);
 
-		return $exitCode === 0;
+		if ($exitCode !== 0) {
+			// Background subshell never started, so the cleanup `rm` won't run.
+			@unlink($tempPath);
+
+			return false;
+		}
+
+		return true;
 	}
 
 

--- a/tests/fixtures/fake-curl.php
+++ b/tests/fixtures/fake-curl.php
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php declare(strict_types = 1);
+
+$args = array_slice($_SERVER['argv'], 1);
+
+$uploadFile = null;
+for ($i = 0, $n = count($args); $i < $n; $i++) {
+	if ($args[$i] === '--upload-file' && isset($args[$i + 1])) {
+		$uploadFile = $args[$i + 1];
+		break;
+	}
+}
+
+if ($uploadFile === null) {
+	exit(1);
+}
+
+$sleepUs = (int) (getenv('FAKE_CURL_SLEEP_US') ?: '0');
+$outputTarget = getenv('FAKE_CURL_OUTPUT');
+$pathRecord = getenv('FAKE_CURL_UPLOAD_PATH');
+
+if ($sleepUs > 0) {
+	usleep($sleepUs);
+}
+
+$content = @file_get_contents($uploadFile);
+
+if ($content === false) {
+	exit(2);
+}
+
+if ($outputTarget !== false && $outputTarget !== '') {
+	file_put_contents($outputTarget, $content);
+}
+
+if ($pathRecord !== false && $pathRecord !== '') {
+	file_put_contents($pathRecord, $uploadFile);
+}
+
+exit(0);

--- a/tests/unit/RemoteStorageRequestSenders/ExecCurlRequestSenderTest.phpt
+++ b/tests/unit/RemoteStorageRequestSenders/ExecCurlRequestSenderTest.phpt
@@ -1,0 +1,116 @@
+<?php declare(strict_types = 1);
+
+namespace MangowebTests\MonologTracyHandler\RemoteStorageRequestSenders;
+
+use Mangoweb\MonologTracyHandler\RemoteStorageRequestSenders\ExecCurlRequestSender;
+use Tester\Assert;
+use Tester\TestCase;
+
+
+/** @testCase */
+(require __DIR__ . '/../../bootstrap.php')(
+	new class extends TestCase
+	{
+		private string $bodyFile;
+		private string $outputFile;
+		private string $pathRecordFile;
+
+
+		protected function setUp(): void
+		{
+			parent::setUp();
+
+			$this->bodyFile = tempnam(sys_get_temp_dir(), 'body-');
+			$this->outputFile = tempnam(sys_get_temp_dir(), 'output-');
+			$this->pathRecordFile = tempnam(sys_get_temp_dir(), 'path-');
+
+			putenv("FAKE_CURL_OUTPUT={$this->outputFile}");
+			putenv("FAKE_CURL_UPLOAD_PATH={$this->pathRecordFile}");
+		}
+
+
+		protected function tearDown(): void
+		{
+			@unlink($this->bodyFile);
+			@unlink($this->outputFile);
+			@unlink($this->pathRecordFile);
+
+			putenv('FAKE_CURL_OUTPUT');
+			putenv('FAKE_CURL_UPLOAD_PATH');
+			putenv('FAKE_CURL_SLEEP_US');
+
+			parent::tearDown();
+		}
+
+
+		public function testSyncUploadReadsOriginalFile(): void
+		{
+			file_put_contents($this->bodyFile, 'original-content');
+
+			$sender = new ExecCurlRequestSender(__DIR__ . '/../../fixtures/fake-curl.php', async: false);
+			$ok = $sender->sendRequest('PUT', 'http://example/', [], $this->bodyFile);
+
+			Assert::true($ok);
+			Assert::same('original-content', file_get_contents($this->outputFile));
+			Assert::same($this->bodyFile, file_get_contents($this->pathRecordFile));
+		}
+
+
+		public function testAsyncUploadUsesTempCopyAndSurvivesOverwrite(): void
+		{
+			file_put_contents($this->bodyFile, 'original-content');
+			putenv('FAKE_CURL_SLEEP_US=300000');
+
+			$sender = new ExecCurlRequestSender(__DIR__ . '/../../fixtures/fake-curl.php', async: true);
+			$ok = $sender->sendRequest('PUT', 'http://example/', [], $this->bodyFile);
+
+			Assert::true($ok);
+
+			// Simulate TracyHandler truncating the local file while the
+			// backgrounded curl is still "uploading".
+			file_put_contents($this->bodyFile, 'overwritten');
+
+			$this->waitForFile($this->outputFile, minBytes: 1);
+
+			Assert::same('original-content', file_get_contents($this->outputFile));
+			Assert::notSame($this->bodyFile, file_get_contents($this->pathRecordFile));
+		}
+
+
+		public function testAsyncUploadCleansUpTempCopy(): void
+		{
+			file_put_contents($this->bodyFile, 'original-content');
+			putenv('FAKE_CURL_SLEEP_US=100000');
+
+			$sender = new ExecCurlRequestSender(__DIR__ . '/../../fixtures/fake-curl.php', async: true);
+			$sender->sendRequest('PUT', 'http://example/', [], $this->bodyFile);
+
+			$this->waitForFile($this->outputFile, minBytes: 1);
+
+			$tempPath = file_get_contents($this->pathRecordFile);
+			Assert::type('string', $tempPath);
+
+			// rm happens in the background shell after curl; give it a beat.
+			$deadline = microtime(true) + 2.0;
+			while (file_exists($tempPath) && microtime(true) < $deadline) {
+				usleep(20_000);
+			}
+
+			Assert::false(file_exists($tempPath));
+		}
+
+
+		private function waitForFile(string $path, int $minBytes): void
+		{
+			$deadline = microtime(true) + 5.0;
+
+			while (microtime(true) < $deadline) {
+				clearstatcache(true, $path);
+				if (is_file($path) && filesize($path) >= $minBytes) {
+					return;
+				}
+				usleep(20_000);
+			}
+		}
+	}
+);

--- a/tests/unit/RemoteStorageRequestSenders/ExecCurlRequestSenderTest.phpt
+++ b/tests/unit/RemoteStorageRequestSenders/ExecCurlRequestSenderTest.phpt
@@ -71,9 +71,14 @@ use Tester\TestCase;
 			file_put_contents($this->bodyFile, 'overwritten');
 
 			$this->waitForFile($this->outputFile, minBytes: 1);
+			$this->waitForFile($this->pathRecordFile, minBytes: 1);
 
 			Assert::same('original-content', file_get_contents($this->outputFile));
-			Assert::notSame($this->bodyFile, file_get_contents($this->pathRecordFile));
+
+			$recordedPath = file_get_contents($this->pathRecordFile);
+			Assert::type('string', $recordedPath);
+			Assert::notSame('', $recordedPath);
+			Assert::notSame($this->bodyFile, $recordedPath);
 		}
 
 
@@ -86,9 +91,11 @@ use Tester\TestCase;
 			$sender->sendRequest('PUT', 'http://example/', [], $this->bodyFile);
 
 			$this->waitForFile($this->outputFile, minBytes: 1);
+			$this->waitForFile($this->pathRecordFile, minBytes: 1);
 
 			$tempPath = file_get_contents($this->pathRecordFile);
 			Assert::type('string', $tempPath);
+			Assert::notSame('', $tempPath);
 
 			// rm happens in the background shell after curl; give it a beat.
 			$deadline = microtime(true) + 2.0;


### PR DESCRIPTION
## Summary
- Fixes the race described in #10 by localizing the fix to the only component that actually runs asynchronously: `ExecCurlRequestSender`.
- In async mode, `sendRequest()` now copies the body file to a temp path, spawns curl against that copy, and removes the copy from the background shell once curl is done.
- Synchronous callers and non-curl `RemoteStorageRequestSender` implementations are unchanged — they pay no copy cost.

## Why not patch `TracyHandler` (as in #13)?
#13 moves the temp-copy into `TracyHandler::write`, which works but has two downsides:
1. Every bluescreen pays the copy, even when the configured sender uploads synchronously (CLI, or a custom sender).
2. The handler ends up compensating for one specific sender's fire-and-forget contract — it leaks the async detail upward instead of containing it.

Putting the copy inside `ExecCurlRequestSender` keeps the abstraction clean: the sender that *creates* the async lifetime also owns it. The `TracyHandler` overwrite is safe again because curl is reading a private temp file, not the path the caller holds. Unlink-while-open on POSIX means the cleanup `rm -f` from the background shell doesn't interfere with an in-flight upload.

## Test plan
- [x] Added `ExecCurlRequestSenderTest` with three cases (sync path, async survives caller overwrite, async cleans up temp copy), using a tiny `tests/fixtures/fake-curl.php` as the curl stand-in.
- [x] `vendor/bin/tester tests/` — 10/10 pass.
- [x] `vendor/bin/phpstan analyse` — clean.

Refs #10, alternative to #13.