### PR TITLE
AwsS3RemoteStorageDriver: add optional $endpoint for S3-compatible services

### DIFF
--- a/src/RemoteStorageDrivers/AwsS3RemoteStorageDriver.php
+++ b/src/RemoteStorageDrivers/AwsS3RemoteStorageDriver.php
@@ -11,6 +11,14 @@ class AwsS3RemoteStorageDriver implements RemoteStorageDriver
 {
 	private const UNSIGNED_PAYLOAD_HASH = 'UNSIGNED-PAYLOAD';
 
+	private readonly string $baseUrl;
+	private readonly string $hostHeader;
+
+	/**
+	 * @param string|null $endpoint Base URL (scheme + host [+ port]) of an S3-compatible endpoint,
+	 *                              e.g. "https://minio.example.com:9000" or "http://localhost:9000".
+	 *                              When null, the official AWS endpoint "https://s3.{region}.amazonaws.com" is used.
+	 */
 	public function __construct(
 		private string $region,
 		private string $bucket,
@@ -19,15 +27,33 @@ class AwsS3RemoteStorageDriver implements RemoteStorageDriver
 		private string $secretKey,
 		private RemoteStorageRequestSender $requestSender,
 		private ?AwsS3Acl $acl = null,
+		?string $endpoint = null,
 	) {
+		if ($endpoint === null) {
+			$this->baseUrl = "https://s3.{$region}.amazonaws.com";
+			$this->hostHeader = "s3.{$region}.amazonaws.com";
+		} else {
+			$endpoint = rtrim($endpoint, '/');
+			$parts = parse_url($endpoint);
+			$allowedKeys = ['scheme', 'host', 'port'];
+			if (!is_array($parts)
+				|| !isset($parts['scheme'], $parts['host'])
+				|| !in_array($parts['scheme'], ['http', 'https'], true)
+				|| array_diff(array_keys($parts), $allowedKeys) !== []
+			) {
+				throw new \InvalidArgumentException(
+					"Invalid endpoint \"$endpoint\", expected URL in the form \"scheme://host[:port]\"."
+				);
+			}
+			$this->baseUrl = $endpoint;
+			$this->hostHeader = $parts['host'] . (isset($parts['port']) ? ':' . $parts['port'] : '');
+		}
 	}
 
 
 	public function getUrl(string $localName): string
 	{
-		$host = $this->getUrlHost();
-		$path = $this->getUrlPath($localName);
-		return "https://{$host}{$path}";
+		return $this->baseUrl . $this->getUrlPath($localName);
 	}
 
 
@@ -40,7 +66,7 @@ class AwsS3RemoteStorageDriver implements RemoteStorageDriver
 		$method = 'PUT';
 
 		$headers = [
-			'Host' => $this->getUrlHost(),
+			'Host' => $this->hostHeader,
 			'User-Agent' => 'MangoLogger',
 			'X-Amz-Content-Sha256' => self::UNSIGNED_PAYLOAD_HASH,
 			'X-Amz-Date' => Clock::now()->format('Ymd\THis\Z'),
@@ -59,12 +85,6 @@ class AwsS3RemoteStorageDriver implements RemoteStorageDriver
 		} catch (\Throwable $e) {
 			return false;
 		}
-	}
-
-
-	private function getUrlHost(): string
-	{
-		return "s3.{$this->region}.amazonaws.com";
 	}
 
 

--- a/tests/unit/RemoteStorageDrivers/AwsS3RemoteStorageDriverTest.phpt
+++ b/tests/unit/RemoteStorageDrivers/AwsS3RemoteStorageDriverTest.phpt
@@ -66,6 +66,72 @@ use Tester\TestCase;
 		}
 
 
+		public function testGetUrlWithCustomEndpoint(): void
+		{
+			$requestSender = Mockery::mock(RemoteStorageRequestSender::class);
+			$storageDriver = $this->createStorageDriver($requestSender, endpoint: 'https://minio.example.com:9000');
+
+			Assert::same(
+				'https://minio.example.com:9000/my-app/logs/a5ef95ed6b795b3dfed85238d3003cae.html',
+				$storageDriver->getUrl('exception--2018-10-09--144c575abe.html')
+			);
+		}
+
+
+		public function testGetUrlWithCustomEndpointTrailingSlashIsStripped(): void
+		{
+			$requestSender = Mockery::mock(RemoteStorageRequestSender::class);
+			$storageDriver = $this->createStorageDriver($requestSender, endpoint: 'http://localhost:9000/');
+
+			Assert::same(
+				'http://localhost:9000/my-app/logs/a5ef95ed6b795b3dfed85238d3003cae.html',
+				$storageDriver->getUrl('exception--2018-10-09--144c575abe.html')
+			);
+		}
+
+
+		public function testUploadWithCustomEndpoint(): void
+		{
+			$requestSender = Mockery::mock(RemoteStorageRequestSender::class);
+			$requestSender->expects('sendRequest')
+				->andReturnUsing(function (string $method, string $url, array $headers, string $bodyFilePath): bool {
+					Assert::same('PUT', $method);
+					Assert::same('http://localhost:9000/my-app/logs/a5ef95ed6b795b3dfed85238d3003cae.html', $url);
+					Assert::same('/src/log/exception--2018-10-09--144c575abe.html', $bodyFilePath);
+
+					Assert::count(6, $headers);
+					Assert::same('localhost:9000', $headers['Host']);
+					Assert::same('MangoLogger', $headers['User-Agent']);
+					Assert::same('UNSIGNED-PAYLOAD', $headers['X-Amz-Content-Sha256']);
+					Assert::same('20181009T213200Z', $headers['X-Amz-Date']);
+					Assert::match(
+						'AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20181009/eu-central-1/s3/aws4_request, SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=%h%',
+						$headers['Authorization']
+					);
+					Assert::same('text/html; charset=utf-8', $headers['Content-Type']);
+
+					return true;
+				});
+
+			$storageDriver = $this->createStorageDriver($requestSender, endpoint: 'http://localhost:9000');
+			Assert::true($storageDriver->upload('/src/log/exception--2018-10-09--144c575abe.html'));
+		}
+
+
+		public function testInvalidEndpointThrows(): void
+		{
+			$requestSender = Mockery::mock(RemoteStorageRequestSender::class);
+
+			foreach (['not-a-url', 'ftp://host', 'https://host/path', 'https://host?q=1', 'https://u:p@host'] as $bad) {
+				Assert::exception(
+					fn() => $this->createStorageDriver($requestSender, endpoint: $bad),
+					\InvalidArgumentException::class,
+					"Invalid endpoint \"%a%\", expected URL in the form \"scheme://host[:port]\"."
+				);
+			}
+		}
+
+
 		public function testUploadWithAcl(): void
 		{
 			$requestSender = Mockery::mock(RemoteStorageRequestSender::class);
@@ -92,7 +158,11 @@ use Tester\TestCase;
 		}
 
 
-		private function createStorageDriver(RemoteStorageRequestSender $requestSender, ?AwsS3Acl $acl = null): AwsS3RemoteStorageDriver
+		private function createStorageDriver(
+			RemoteStorageRequestSender $requestSender,
+			?AwsS3Acl $acl = null,
+			?string $endpoint = null,
+		): AwsS3RemoteStorageDriver
 		{
 			return new AwsS3RemoteStorageDriver(
 				'eu-central-1',
@@ -102,6 +172,7 @@ use Tester\TestCase;
 				' wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
 				$requestSender,
 				$acl,
+				$endpoint,
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

Adds an optional `$endpoint` constructor argument to `AwsS3RemoteStorageDriver` so the driver can target S3-compatible object stores (MinIO, Cloudflare R2, Backblaze B2, Ceph, …) or a custom CDN/proxy domain. When omitted, behavior is unchanged — the official `https://s3.{region}.amazonaws.com` endpoint is used.

```php
new AwsS3RemoteStorageDriver(
    region: 'eu-central-1',
    bucket: 'my-app',
    prefix: 'logs/',
    accessKeyId: '…',
    secretKey: '…',
    requestSender: $requestSender,
    endpoint: 'https://minio.example.com:9000',
);
```

## Design notes

Alternative #11 introduced `hostOverride: 'minio.example.com'`, which couldn't express:
- `http://` endpoints (MinIO/local dev) — protocol was hardcoded to `https://`
- non-default ports cleanly (it "worked" only because a host-with-port string happened to slot into both the URL and the `Host` header)

Taking a full base URL instead matches how the AWS SDK exposes this (`endpoint` option) and cleanly decouples scheme, host, and port. The endpoint is parsed and validated once in the constructor:

- scheme must be `http` or `https`
- must not contain path/query/fragment/userinfo
- trailing slash is stripped
- parsed parts are stashed in `$baseUrl` / `$hostHeader` so no reparsing per upload

Signing still uses the configured `region` and the `s3` service — that's what all S3-compatible services in practice expect.

## Test plan

- [x] Existing tests still pass (3 → 7 in this file)
- [x] `getUrl()` returns `https://minio.example.com:9000/…` when endpoint is set
- [x] Trailing slash on endpoint is stripped
- [x] `upload()` sets correct `Host` header (`localhost:9000`) for a `http://localhost:9000` endpoint, and signature matches the new host
- [x] Invalid endpoints throw `\InvalidArgumentException` (not a URL, wrong scheme, has path / query / userinfo)
- [x] `vendor/bin/tester tests/` — 14 tests pass
- [x] `vendor/bin/phpstan analyse` — no errors